### PR TITLE
Fix paths after mechanism split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.ipynb

--- a/extract_reactions.py
+++ b/extract_reactions.py
@@ -7,7 +7,7 @@ string along with Arrhenius parameters A, Ta, and b.
 Usage:
     python extract_reactions.py [PATH_TO_YAML]
 
-If no path is given, ``cantera/chem.yaml`` is used.
+If no path is given, ``singleStep/cantera/chem.yaml`` is used.
 """
 
 import os
@@ -50,9 +50,12 @@ def main(yaml_path: str) -> None:
             b = rate.temperature_exponent
             Ea = rate.activation_energy
         except AttributeError:
-            A = rate.A
-            b = rate.b
-            Ea = rate.Ea
+            A = getattr(rate, "A", None)
+            b = getattr(rate, "b", None)
+            Ea = getattr(rate, "Ea", None)
+        if None in (A, b, Ea):
+            print("  Arrhenius parameters not available for this reaction type\n")
+            continue
         Ta = Ea / ct.gas_constant
         print(f"  A  = {A}")
         print(f"  Ta = {Ta}")
@@ -60,5 +63,7 @@ def main(yaml_path: str) -> None:
 
 
 if __name__ == "__main__":
-    path = sys.argv[1] if len(sys.argv) > 1 else os.path.join("cantera", "chem.yaml")
+    ROOT = os.path.dirname(os.path.abspath(__file__))
+    default = os.path.join(ROOT, "singleStep", "cantera", "chem.yaml")
+    path = sys.argv[1] if len(sys.argv) > 1 else default
     main(path)

--- a/main.py
+++ b/main.py
@@ -1,12 +1,34 @@
+import os
 from canteraToFoam import canteraToFoam
 
 
-def main():
-    yaml_path = "cantera/chem.yaml"
+ROOT = os.path.dirname(os.path.abspath(__file__))
+
+
+def main(mech: str = "single", thermo_only: bool = False):
+    """Run a small demonstration using the requested mechanism.
+
+    Parameters
+    ----------
+    mech
+        Either "single" or "multi" to select the mechanism.
+    thermo_only
+        If True, print only the OpenFOAM thermo file.
+    """
+
+    base = os.path.join(ROOT, "singleStep" if mech == "single" else "multiStep")
+    yaml_name = "chem.yaml" if mech == "single" else "grimech30.yaml"
+    yaml_path = os.path.join(base, "cantera", yaml_name)
     try:
         ctf = canteraToFoam(yaml_path)
     except ImportError as exc:
         print(f"Cannot run example: {exc}")
+        return
+
+    t_data = ctf.read_transport(os.path.join(base, "chemkin", "transportProperties"))
+    thermo_str = ctf.thermo_file_string(transport=t_data)
+    if thermo_only:
+        print(thermo_str)
         return
 
     A, Ta, b = ctf.get_arrhenius_parameters(0)
@@ -15,8 +37,6 @@ def main():
     orders = ctf.reaction_orders(0)
     print("Forward orders:", orders)
 
-    t_data = ctf.read_transport("chemkin/transportProperties")
-    thermo_str = ctf.thermo_file_string(transport=t_data)
     print("\nGenerated OpenFOAM thermo file:\n")
     print(thermo_str)
 
@@ -26,4 +46,11 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    import sys
+    mech = "single"
+    thermo_only = False
+    if len(sys.argv) > 1:
+        mech = sys.argv[1]
+    if len(sys.argv) > 2 and sys.argv[2] == "thermo":
+        thermo_only = True
+    main(mech, thermo_only)


### PR DESCRIPTION
## Summary
- point example scripts to `singleStep` paths
- allow choosing single or multi mechanism in `main.py`
- compute paths relative to the repository root
- handle missing Arrhenius data when extracting reactions
- add option to output only the thermo file
- add `.gitignore` for caches and notebooks

## Testing
- `python main.py > /tmp/main_single.out && tail -n 2 /tmp/main_single.out`
- `python main.py multi > /tmp/multi_full.out && head -n 5 /tmp/multi_full.out`
- `python main.py multi thermo > /tmp/multi_thermo.out && head -n 5 /tmp/multi_thermo.out`
- `python extract_reactions.py multiStep/cantera/grimech30.yaml > /tmp/multi_extr.out && head -n 5 /tmp/multi_extr.out`


------
https://chatgpt.com/codex/tasks/task_e_6852b51968508328935843350c9e0192