### PR TITLE
Fix Troe parsing and add plog tests

### DIFF
--- a/test
+++ b/test
@@ -1,4 +1,6 @@
 rm -rf ./singleStep/output/*
 rm -rf ./multiStep/output/*
+rm -rf ./plog/output/*
 python main.py ./singleStep/cantera/ ./singleStep/output/
 python main.py ./multiStep/cantera/ ./multiStep/output/
+python main.py ./plog/cantera/ ./plog/output/


### PR DESCRIPTION
## Summary
- handle Troe falloff parameters when Tss is omitted
- run plog mechanism in test script

## Testing
- `python -m py_compile canteraToFoam.py`
- `./test`

------
https://chatgpt.com/codex/tasks/task_e_685474271c8c8328b8f29a614a298a9f